### PR TITLE
Create docker-image.yml

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,31 @@
+name: Docker Image CI/CD
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: install buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          install: true # set default builder
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+      - name: login to docker hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USER }}" --password-stdin
+      - name: build and push images
+        run: |
+          docker build --push --platform linux/amd64 --tag $GITHUB_ACTOR/kodi-server .
+          echo 'All done :-)'


### PR DESCRIPTION
This is github action to trigger docker image build and push to docker hub registry. You have to set DOCKER_USER and DOCKER_PASSWORD secrets in settings in order to login to the hub.docker.

This action file is prepared to create multi-arch builds, however no ARM platforms pass the build yet. They break on
kodi-11 dependecy.